### PR TITLE
Add simple Flask chat interface

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>Malaysia GeoGPT Chat</title>
+</head>
+<body>
+<div class="container-fluid py-4">
+    <h1 class="text-center mb-4">Malaysia GeoGPT Chat</h1>
+    <div class="row">
+        <div class="col-md-8">
+            <div class="border rounded p-3 mb-3" id="chat-box" style="height:50vh; overflow-y:auto;">
+                {% if history %}
+                    {% for role, content in history %}
+                        <div class="mb-2">
+                            <span class="fw-bold text-primary">{{ role.capitalize() }}:</span>
+                            <span>{{ content }}</span>
+                        </div>
+                    {% endfor %}
+                {% else %}
+                    <p class="text-muted">Ask a question to begin.</p>
+                {% endif %}
+            </div>
+            <form method="post" class="mb-2">
+                {% if results %}
+                    <div class="mb-3">
+                        <label for="interrogation" class="form-label">Ask a follow up question</label>
+                        <input type="text" class="form-control" id="interrogation" name="interrogation" required>
+                    </div>
+                    <button type="submit" name="interrogate" class="btn btn-primary">Ask</button>
+                {% else %}
+                    <div class="mb-3">
+                        <label for="query" class="form-label">Your question</label>
+                        <input type="text" class="form-control" id="query" name="query" required>
+                    </div>
+                    <button type="submit" class="btn btn-primary">Search</button>
+                {% endif %}
+                <button type="submit" name="reset" class="btn btn-secondary ms-2">Reset</button>
+            </form>
+        </div>
+        <div class="col-md-4 border-start">
+            <h5>Search Results</h5>
+            <ul class="list-unstyled">
+                {% if results %}
+                    {% for row in results %}
+                        <li class="mb-3">
+                            <a href="{{ row[3] }}" target="_blank" class="fw-semibold">{{ row[1] }}</a><br>
+                            <small class="text-muted">Author: {{ row[2] }}</small>
+                            <p class="mb-0">{{ row[4] }}</p>
+                        </li>
+                    {% endfor %}
+                {% else %}
+                    <li class="text-muted">No results yet.</li>
+                {% endif %}
+            </ul>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,58 @@
+from flask import Flask, render_template, request, redirect, url_for, session
+from LLM.VectorSearch import VectorSearch
+from LLM.Chat import Chat
+
+app = Flask(__name__)
+app.secret_key = 'change-me'
+
+ROLE = """a geology data calatog experts for malaysia. \
+                       ONLY USE THE DATA PROVIDED AND AVOID USE YOUR OWN KNOWLEDGE. \
+                       ENSURE AT THE BOTTOM OF YOUR RESPONSE ADD THE TITLE AND URL THAT YOU USE FOR REFERENCE. \
+                       YOU ARE FOUND TO ALWAYS GET MIXED UP ON GEOGRAPHY LIKE SARAWAK IN PERAK. ENSURE YOU GOT THIS RIGHT WHEN GIVING ANSWER.\n                       """
+
+def reset_session():
+    session['history'] = []
+    session['results'] = None
+    session['last_answer'] = None
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if 'history' not in session:
+        reset_session()
+    if request.method == 'POST':
+        if 'reset' in request.form:
+            reset_session()
+            return redirect(url_for('index'))
+        # follow-up question
+        if session.get('results') and 'interrogate' in request.form:
+            interrogation = request.form.get('interrogation')
+            previous = session.get('last_answer')
+            chat = Chat()
+            answer = chat.execute(interrogation, ROLE, previous)
+            session['history'].append(('user', interrogation))
+            session['history'].append(('assistant', answer))
+            session['last_answer'] = answer
+            return redirect(url_for('index'))
+        # new query
+        query = request.form.get('query')
+        if query:
+            vs = VectorSearch()
+            results = vs.execute(query)
+            session['results'] = results
+            result_str = ""
+            for res in results:
+                result_str += (
+                    f"title: {res[1]}author: {res[2]}url: {res[3]}"
+                    f"abstract: {res[4]}\n"
+                )
+            prompt = f"Based on the following data: {result_str} + summarize and answer the following query from the user: {query}"
+            chat = Chat()
+            answer = chat.execute(prompt, ROLE)
+            session['history'].append(('user', query))
+            session['history'].append(('assistant', answer))
+            session['last_answer'] = answer
+            return redirect(url_for('index'))
+    return render_template('index.html', history=session.get('history'), results=session.get('results'))
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add Bootstrap-based HTML chat interface with sidebar for results
- implement `webapp.py` to search, chat, and follow-up using existing LLM modules
- rename page to Malaysia GeoGPT Chat

## Testing
- `python -m py_compile webapp.py`


------
https://chatgpt.com/codex/tasks/task_e_6852b6a671308325888342a52fcf07eb