### PR TITLE
Redesign search page

### DIFF
--- a/app.py
+++ b/app.py
@@ -75,7 +75,10 @@ def index():
             store['history'].append(('assistant', answer))
             store['last_answer'] = answer
             return redirect(url_for('index'))
-    return render_template('index.html', history=store.get('history'), results=store.get('results'))
+    return render_template('index.html',
+                           history=store.get('history'),
+                           results=store.get('results'),
+                           summary=store.get('last_answer'))
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,73 +5,56 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <title>Malaysia GeoGPT Chat</title>
+    <style>
+        body { background-color: #fff; }
+        .search-container { margin-top: 15vh; }
+        .search-box { max-width: 600px; margin: 0 auto; }
+    </style>
 </head>
 <body>
-<div class="container-fluid py-4">
-    <h1 class="text-center mb-4">Malaysia GeoGPT Chat</h1>
-    <div class="mb-4">
-        <p class="text-start">
-            <strong>What is Malaysia GeoGPT?</strong><br>
-            Malaysia GeoGPT is a geology-focused chatbot that helps researchers, students, and enthusiasts find answers directly from academic paper abstracts published by UM and UTP. It uses AI-powered vector search to retrieve the most relevant papers — so you can skip the tedious filtering and go straight to the insights.
-        </p>
-        <p class="text-start">
-            <strong>Try asking:</strong><br>
-            • What are the main fault zones in Peninsular Malaysia?<br>
-            • Provide summary about Belait formation<br>
-            • Which papers discuss on seismic interpretation and attributes?
-        </p>
-        <p class="text-muted">
-            Use the <strong>Reset</strong> button to clear the chat and run a new
-            vector search so GPT can analyze fresh results.
-        </p>
-    </div>
-    <div class="row">
-        <div class="col-md-8">
-            <div class="border rounded p-3 mb-3" id="chat-box" style="height:50vh; overflow-y:auto;">
-                {% if history %}
-                    {% for role, content in history %}
-                        <div class="mb-2">
-                            <span class="fw-bold text-primary">{{ role.capitalize() }}:</span>
-                            <div style="white-space: pre-wrap;" class="d-inline">{{ content }}</div>
-                        </div>
-                    {% endfor %}
-                {% else %}
-                    <p class="text-muted">Ask a question to begin.</p>
-                {% endif %}
-            </div>
-            <form method="post" class="mb-2">
-                {% if results %}
-                    <div class="mb-3">
-                        <label for="interrogation" class="form-label">Ask a follow up question</label>
-                        <input type="text" class="form-control" id="interrogation" name="interrogation" required>
-                    </div>
-                    <button type="submit" name="interrogate" class="btn btn-primary">Ask</button>
-                {% else %}
-                    <div class="mb-3">
-                        <label for="query" class="form-label">Your question</label>
-                        <input type="text" class="form-control" id="query" name="query" required>
-                    </div>
-                    <button type="submit" class="btn btn-primary">Search</button>
-                {% endif %}
-                <button type="submit" name="reset" class="btn btn-secondary ms-2" formnovalidate>Reset</button>
-            </form>
+<div class="container search-container text-center">
+    <h1 class="mb-4">Malaysia GeoGPT Chat</h1>
+    <form method="post" class="search-box">
+        <div class="input-group input-group-lg mb-3">
+            <input type="text" id="query" name="query" class="form-control" placeholder="Search geology papers..." required>
+            <button type="submit" class="btn btn-primary">Search</button>
+            <button type="submit" name="reset" class="btn btn-secondary" formnovalidate>Reset</button>
         </div>
-        <div class="col-md-4 border-start">
-            <h5>Search Results</h5>
-            <ol class="ps-3">
-                {% if results %}
-                    {% for row in results %}
-                        <li class="mb-3">
-                            <a href="{{ row[3] }}" target="_blank" class="fw-semibold">{{ row[1] }}</a><br>
-                            <small class="text-muted">Author: {{ row[2] }}</small>
-                        </li>
-                    {% endfor %}
-                {% else %}
-                    <li class="text-muted">No results yet.</li>
-                {% endif %}
-            </ol>
-        </div>
+    </form>
+    <div class="text-start mx-auto" style="max-width:600px;">
+        <p><strong>What is Malaysia GeoGPT?</strong><br>
+        Malaysia GeoGPT is a geology-focused chatbot that helps researchers, students, and enthusiasts find answers directly from academic paper abstracts published by UM and UTP. It uses AI-powered vector search to retrieve the most relevant papers — so you can skip the tedious filtering and go straight to the insights.</p>
+        <p><strong>Try asking:</strong><br>
+        • What are the main fault zones in Peninsular Malaysia?<br>
+        • Provide summary about Belait formation<br>
+        • Which papers discuss on seismic interpretation and attributes?</p>
+        <p class="text-muted">Use the <strong>Reset</strong> button to clear the chat and run a new vector search so GPT can analyze fresh results.</p>
     </div>
 </div>
+
+{% if summary %}
+<div class="container mt-5" style="max-width:800px;">
+    <h5>AI Summary</h5>
+    <p>{{ summary }}</p>
+    <form method="post" class="d-flex mb-4">
+        <input type="text" name="interrogation" class="form-control me-2" placeholder="Ask a follow-up question" required>
+        <button type="submit" name="interrogate" class="btn btn-primary">Chat</button>
+    </form>
+</div>
+{% endif %}
+
+{% if results %}
+<div class="container" style="max-width:800px;">
+    <h5>Results</h5>
+    <ol class="ps-3">
+        {% for row in results %}
+        <li class="mb-3">
+            <a href="{{ row[3] }}" target="_blank" class="fw-semibold">{{ row[1] }}</a><br>
+            <small class="text-muted">Author: {{ row[2] }}</small>
+        </li>
+        {% endfor %}
+    </ol>
+</div>
+{% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign the homepage to resemble a Google-style search interface
- always display the search bar and show AI summary above results
- allow follow-up questions via a chat button

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686539851c8083258d08094cc87a0a6f