### PR TITLE
Implement separate chat interface

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,8 @@ def _init_store(sid):
     SESSION_STORE[sid] = {
         'history': [],
         'results': None,
-        'last_answer': None
+        'last_answer': None,
+        'last_query': None
     }
 
 def reset_session():
@@ -41,25 +42,10 @@ def _get_store():
 def index():
     store = _get_store()
     if request.method == 'POST':
-        if 'reset' in request.form:
-            reset_session()
-            return redirect(url_for('index'))
-        # follow-up question
-        if store.get('results') and 'interrogate' in request.form:
-            interrogation = request.form.get('interrogation')
-            previous = store.get('last_answer')
-            chat = Chat()
-            answer = chat.execute(interrogation, ROLE, previous)
-            store['history'].append(('user', interrogation))
-            store['history'].append(('assistant', answer))
-            store['last_answer'] = answer
-            return redirect(url_for('index'))
-        # new query
         query = request.form.get('query')
         if query:
             vs = VectorSearch()
             results = vs.execute(query)
-            # Convert SQLAlchemy Row objects to tuples so they can be stored in the session
             results = [tuple(row) for row in results]
             store['results'] = results
             result_str = ""
@@ -68,14 +54,62 @@ def index():
                     f"title: {res[1]}author: {res[3]}url: {res[2]}"
                     f"abstract: {res[4]}\n"
                 )
-            prompt = f"Based on the following data: {result_str} + summarize and answer the following query from the user: {query}"
+            prompt = (
+                f"Based on the following data: {result_str} + summarize and answer the following query from the user: {query}"
+            )
             chat = Chat()
             answer = chat.execute(prompt, ROLE)
-            store['history'].append(('user', query))
+            store['history'] = [('user', query), ('assistant', answer)]
+            store['last_answer'] = answer
+            store['last_query'] = query
+        return redirect(url_for('index'))
+    return render_template(
+        'index.html',
+        results=store.get('results'),
+        summary=store.get('last_answer'),
+        query=store.get('last_query'),
+    )
+
+
+@app.route('/chat', methods=['GET', 'POST'])
+def chat_page():
+    store = _get_store()
+    if request.method == 'POST':
+        if 'query' in request.form:
+            query = request.form.get('query')
+            if query:
+                vs = VectorSearch()
+                results = vs.execute(query)
+                results = [tuple(row) for row in results]
+                store['results'] = results
+                result_str = ""
+                for res in results:
+                    result_str += (
+                        f"title: {res[1]}author: {res[3]}url: {res[2]}"
+                        f"abstract: {res[4]}\n"
+                    )
+                prompt = (
+                    f"Based on the following data: {result_str} + summarize and answer the following query from the user: {query}"
+                )
+                chat = Chat()
+                answer = chat.execute(prompt, ROLE)
+                store['history'].append(('user', query))
+                store['history'].append(('assistant', answer))
+                store['last_answer'] = answer
+        elif 'interrogate' in request.form:
+            interrogation = request.form.get('interrogation')
+            previous = store.get('last_answer')
+            chat = Chat()
+            answer = chat.execute(interrogation, ROLE, previous)
+            store['history'].append(('user', interrogation))
             store['history'].append(('assistant', answer))
             store['last_answer'] = answer
-            return redirect(url_for('index'))
-    return render_template('index.html', history=store.get('history'), results=store.get('results'))
+        return redirect(url_for('chat_page'))
+    return render_template(
+        'chat.html',
+        history=store.get('history'),
+        results=store.get('results'),
+    )
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>Malaysia GeoGPT Chat</title>
+</head>
+<body>
+<div class="container-fluid py-4">
+    <h1 class="text-center mb-4">Malaysia GeoGPT Chat</h1>
+    <form method="post" action="{{ url_for('index') }}" class="mb-4">
+        <div class="input-group">
+            <input type="text" id="query" name="query" class="form-control" placeholder="Search geology papers..." required>
+            <button type="submit" class="btn btn-primary">Search</button>
+        </div>
+    </form>
+    <div class="row">
+        <div class="col-md-8">
+            <div class="border rounded p-3 mb-3" id="chat-box" style="height:50vh; overflow-y:auto;">
+                {% if history %}
+                    {% for role, content in history %}
+                        <div class="mb-2">
+                            <span class="fw-bold text-primary">{{ role.capitalize() }}:</span>
+                            <div style="white-space: pre-wrap;" class="d-inline">{{ content }}</div>
+                        </div>
+                    {% endfor %}
+                {% else %}
+                    <p class="text-muted">Ask a question to begin.</p>
+                {% endif %}
+            </div>
+            <form method="post" class="mb-2">
+                <div class="mb-3">
+                    <label for="interrogation" class="form-label">Ask a follow up question</label>
+                    <input type="text" class="form-control" id="interrogation" name="interrogation" required>
+                </div>
+                <button type="submit" name="interrogate" class="btn btn-primary">Ask</button>
+            </form>
+        </div>
+        <div class="col-md-4 border-start">
+            <h5>Search Results</h5>
+            <ol class="ps-3">
+                {% if results %}
+                    {% for row in results %}
+                        <li class="mb-3">
+                            <a href="{{ row[3] }}" target="_blank" class="fw-semibold">{{ row[1] }}</a><br>
+                            <small class="text-muted">Author: {{ row[2] }}</small>
+                        </li>
+                    {% endfor %}
+                {% else %}
+                    <li class="text-muted">No results yet.</li>
+                {% endif %}
+            </ol>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,73 +5,55 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <title>Malaysia GeoGPT Chat</title>
+    <style>
+        body { background-color: #fff; }
+        .search-container { margin-top: 15vh; }
+        .search-box { max-width: 600px; margin: 0 auto; }
+    </style>
 </head>
 <body>
-<div class="container-fluid py-4">
-    <h1 class="text-center mb-4">Malaysia GeoGPT Chat</h1>
-    <div class="mb-4">
-        <p class="text-start">
-            <strong>What is Malaysia GeoGPT?</strong><br>
-            Malaysia GeoGPT is a geology-focused chatbot that helps researchers, students, and enthusiasts find answers directly from academic paper abstracts published by UM and UTP. It uses AI-powered vector search to retrieve the most relevant papers — so you can skip the tedious filtering and go straight to the insights.
-        </p>
-        <p class="text-start">
-            <strong>Try asking:</strong><br>
-            • What are the main fault zones in Peninsular Malaysia?<br>
-            • Provide summary about Belait formation<br>
-            • Which papers discuss on seismic interpretation and attributes?
-        </p>
-        <p class="text-muted">
-            Use the <strong>Reset</strong> button to clear the chat and run a new
-            vector search so GPT can analyze fresh results.
-        </p>
-    </div>
-    <div class="row">
-        <div class="col-md-8">
-            <div class="border rounded p-3 mb-3" id="chat-box" style="height:50vh; overflow-y:auto;">
-                {% if history %}
-                    {% for role, content in history %}
-                        <div class="mb-2">
-                            <span class="fw-bold text-primary">{{ role.capitalize() }}:</span>
-                            <div style="white-space: pre-wrap;" class="d-inline">{{ content }}</div>
-                        </div>
-                    {% endfor %}
-                {% else %}
-                    <p class="text-muted">Ask a question to begin.</p>
-                {% endif %}
-            </div>
-            <form method="post" class="mb-2">
-                {% if results %}
-                    <div class="mb-3">
-                        <label for="interrogation" class="form-label">Ask a follow up question</label>
-                        <input type="text" class="form-control" id="interrogation" name="interrogation" required>
-                    </div>
-                    <button type="submit" name="interrogate" class="btn btn-primary">Ask</button>
-                {% else %}
-                    <div class="mb-3">
-                        <label for="query" class="form-label">Your question</label>
-                        <input type="text" class="form-control" id="query" name="query" required>
-                    </div>
-                    <button type="submit" class="btn btn-primary">Search</button>
-                {% endif %}
-                <button type="submit" name="reset" class="btn btn-secondary ms-2" formnovalidate>Reset</button>
-            </form>
+<div class="container search-container text-center">
+    <h1 class="mb-4">Malaysia GeoGPT Chat</h1>
+    <form method="post" class="search-box">
+        <div class="input-group input-group-lg mb-3">
+            <input type="text" id="query" name="query" class="form-control" placeholder="Search geology papers..." required>
+            <button type="submit" class="btn btn-primary">Search</button>
         </div>
-        <div class="col-md-4 border-start">
-            <h5>Search Results</h5>
-            <ol class="ps-3">
-                {% if results %}
-                    {% for row in results %}
-                        <li class="mb-3">
-                            <a href="{{ row[3] }}" target="_blank" class="fw-semibold">{{ row[1] }}</a><br>
-                            <small class="text-muted">Author: {{ row[2] }}</small>
-                        </li>
-                    {% endfor %}
-                {% else %}
-                    <li class="text-muted">No results yet.</li>
-                {% endif %}
-            </ol>
-        </div>
+    </form>
+    <div class="text-start mx-auto" style="max-width:600px;">
+        <p><strong>What is Malaysia GeoGPT?</strong><br>
+        Malaysia GeoGPT is a geology-focused chatbot that helps researchers, students, and enthusiasts find answers directly from academic paper abstracts published by UM and UTP. It uses AI-powered vector search to retrieve the most relevant papers — so you can skip the tedious filtering and go straight to the insights.</p>
+        <p><strong>Try asking:</strong><br>
+        • What are the main fault zones in Peninsular Malaysia?<br>
+        • Provide summary about Belait formation<br>
+        • Which papers discuss on seismic interpretation and attributes?</p>
     </div>
 </div>
+
+{% if summary %}
+<div class="container mt-5" style="max-width:800px;">
+    {% if query %}
+    <h6 class="mb-2">Query</h6>
+    <div class="mb-3" style="white-space: pre-wrap;">{{ query }}</div>
+    {% endif %}
+    <h5>AI Summary</h5>
+    <div style="white-space: pre-wrap;">{{ summary }}</div>
+    <a href="{{ url_for('chat_page') }}" class="btn btn-secondary mt-3">Chat</a>
+</div>
+{% endif %}
+
+{% if results %}
+<div class="container" style="max-width:800px;">
+    <h5>Results</h5>
+    <ol class="ps-3">
+        {% for row in results %}
+        <li class="mb-3">
+            <a href="{{ row[3] }}" target="_blank" class="fw-semibold">{{ row[1] }}</a><br>
+            <small class="text-muted">Author: {{ row[2] }}</small>
+        </li>
+        {% endfor %}
+    </ol>
+</div>
+{% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign the search page with no reset button
- preserve AI summary formatting and link to chat page
- add new chat.html template with history and results side-by-side
- update Flask routes for search and chat flows
- fix chat navigation for returning to index search
- show the query before the AI summary on the search results page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686539851c8083258d08094cc87a0a6f